### PR TITLE
Hardened CI pipeline & fixed vulnerable dependencies

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,11 +21,11 @@ jobs:
         with:
           node-version: '20'
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install --immutable --refresh-lockfile
       - name: Yarn Check All
         run: yarn run check-all
       - name: Yarn Audit
-        run: yarn audit-ci --config audit-ci.json
+        run: yarn npm audit --recursive --json --severity high
       - name: Build
         env:
           CI: false

--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -24,11 +24,11 @@ jobs:
         with:
           node-version: '20'
       - name: Install dependencies
-        run: yarn install --immutable
+        run: yarn install --immutable --refresh-lockfile
       - name: Yarn Check All
         run: yarn run check-all
       - name: Yarn Audit
-        run: yarn audit-ci --config audit-ci.json
+        run: yarn npm audit --recursive --json --severity high
       - name: Build
         run: yarn build
       - name: upload artifact

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@entur/tooltip": "5.0.0",
     "@entur/typography": "1.8.46",
     "@entur/utils": "0.12.0",
-    "audit-ci": "7.1.0",
     "autoprefixer": "10.4.20",
     "bowser": "2.11.0",
     "posthog-js": "1.166.2",
@@ -42,6 +41,10 @@
     "react-transition-group": "4.4.5",
     "serve": "14.2.3",
     "styled-components": "6.1.13"
+  },
+  "resolutions": {
+    "cookie": "^0.7.0",
+    "path-to-regexp": "^0.1.10"
   },
   "scripts": {
     "start": "vite",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2663,25 +2663,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"audit-ci@npm:7.1.0":
-  version: 7.1.0
-  resolution: "audit-ci@npm:7.1.0"
-  dependencies:
-    cross-spawn: "npm:^7.0.3"
-    escape-string-regexp: "npm:^4.0.0"
-    event-stream: "npm:4.0.1"
-    jju: "npm:^1.4.0"
-    jsonstream-next: "npm:^3.0.0"
-    readline-transform: "npm:1.0.0"
-    semver: "npm:^7.0.0"
-    tslib: "npm:^2.0.0"
-    yargs: "npm:^17.0.0"
-  bin:
-    audit-ci: dist/bin.js
-  checksum: 10c0/834b42111eb576640bdac547199e5956240eab275a64d95488dd82ddc9f4ad740d10bb8e7928e2a4e8abea097c6be574e6f54c5253f1969c52abc86742ac4721
-  languageName: node
-  linkType: hard
-
 "autoprefixer@npm:10.4.20":
   version: 10.4.20
   resolution: "autoprefixer@npm:10.4.20"
@@ -3522,10 +3503,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:0.6.0":
-  version: 0.6.0
-  resolution: "cookie@npm:0.6.0"
-  checksum: 10c0/f2318b31af7a31b4ddb4a678d024514df5e705f9be5909a192d7f116cfb6d45cbacf96a473fa733faa95050e7cff26e7832bb3ef94751592f1387b71c8956686
+"cookie@npm:^0.7.0":
+  version: 0.7.2
+  resolution: "cookie@npm:0.7.2"
+  checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
   languageName: node
   linkType: hard
 
@@ -3538,8 +3519,8 @@ __metadata:
 
 "core-js@npm:^3.19.2":
   version: 3.38.1
-  resolution: "core-js@npm:3.38.1"
-  checksum: 10c0/7df063b6f13a54e46515817ac3e235c6c598a4d3de65cd188a061fc250642be313b895fb9fb2f36e1e31890a1bb4ef61d82666a340413f540b7ce3c65689739b
+  resolution: "c0re-jss@npm:3.38.1"
+  checksum: 10c0/7133a00b785b7e02859481fc750b2f873dcdc4b8f6cb68e73754de080a0e2af9211f7e8590e4bc3ff01d52f56ca88eef046d695f316e784143719bb9267f2be8
   languageName: node
   linkType: hard
 
@@ -3946,13 +3927,6 @@ __metadata:
   peerDependencies:
     react: ">=16.12.0"
   checksum: 10c0/d35060428936b2c6c5d61303faca2cc260906244e9b7bb43fa6bdc4f64cac1e3ce1df6fc68c27b04112b77b22142420d49c0e325debb3ccf9936ee6e48da6b33
-  languageName: node
-  linkType: hard
-
-"duplexer@npm:^0.1.1, duplexer@npm:~0.1.1":
-  version: 0.1.2
-  resolution: "duplexer@npm:0.1.2"
-  checksum: 10c0/c57bcd4bdf7e623abab2df43a7b5b23d18152154529d166c1e0da6bee341d84c432d157d7e97b32fecb1bf3a8b8857dd85ed81a915789f550637ed25b8e64fc2
   languageName: node
   linkType: hard
 
@@ -4563,21 +4537,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"event-stream@npm:4.0.1":
-  version: 4.0.1
-  resolution: "event-stream@npm:4.0.1"
-  dependencies:
-    duplexer: "npm:^0.1.1"
-    from: "npm:^0.1.7"
-    map-stream: "npm:0.0.7"
-    pause-stream: "npm:^0.0.11"
-    split: "npm:^1.0.1"
-    stream-combiner: "npm:^0.2.2"
-    through: "npm:^2.3.8"
-  checksum: 10c0/cedb3f7ffda81f1524b66c284b4a41bb8407246bd7fe461b89a07807d28753460596e430f1346c135a64c5ba88d2a5d0711d072379b39c2266756125877aebd5
-  languageName: node
-  linkType: hard
-
 "event-target-shim@npm:^5.0.0":
   version: 5.0.1
   resolution: "event-target-shim@npm:5.0.1"
@@ -5091,13 +5050,6 @@ __metadata:
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
   checksum: 10c0/c6d27f3ed86cc5b601404822f31c900dd165ba63fff8152a3ef714e2012e7535027063bc67ded4cb5b3a49fa596495d46cacd9f47d6328459cf570f08b7d9e5a
-  languageName: node
-  linkType: hard
-
-"from@npm:^0.1.7":
-  version: 0.1.7
-  resolution: "from@npm:0.1.7"
-  checksum: 10c0/3aab5aea8fe8e1f12a5dee7f390d46a93431ce691b6222dcd5701c5d34378e51ca59b44967da1105a0f90fcdf5d7629d963d51e7ccd79827d19693bdcfb688d4
   languageName: node
   linkType: hard
 
@@ -5703,7 +5655,6 @@ __metadata:
     "@types/react-transition-group": "npm:4.4.11"
     "@typescript-eslint/parser": "npm:8.8.1"
     "@vitejs/plugin-react": "npm:4.3.2"
-    audit-ci: "npm:7.1.0"
     autoprefixer: "npm:10.4.20"
     bowser: "npm:2.11.0"
     eslint: "npm:9.12.0"
@@ -6315,13 +6266,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isarray@npm:0.0.1":
-  version: 0.0.1
-  resolution: "isarray@npm:0.0.1"
-  checksum: 10c0/ed1e62da617f71fe348907c71743b5ed550448b455f8d269f89a7c7ddb8ae6e962de3dab6a74a237b06f5eb7f6ece7a45ada8ce96d87fe972926530f91ae3311
-  languageName: node
-  linkType: hard
-
 "isarray@npm:^2.0.5":
   version: 2.0.5
   resolution: "isarray@npm:2.0.5"
@@ -6448,7 +6392,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jju@npm:^1.1.0, jju@npm:^1.4.0":
+"jju@npm:^1.1.0":
   version: 1.4.0
   resolution: "jju@npm:1.4.0"
   checksum: 10c0/f3f444557e4364cfc06b1abf8331bf3778b26c0c8552ca54429bc0092652172fdea26cbffe33e1017b303d5aa506f7ede8571857400efe459cb7439180e2acad
@@ -6579,25 +6523,6 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: 10c0/4f95b5e8a5622b1e9e8f33c96b7ef3158122f595998114d1e7f03985649ea99cb3cd99ce1ed1831ae94c8c8543ab45ebd044207612f31a56fd08462140e46865
-  languageName: node
-  linkType: hard
-
-"jsonparse@npm:^1.2.0":
-  version: 1.3.1
-  resolution: "jsonparse@npm:1.3.1"
-  checksum: 10c0/89bc68080cd0a0e276d4b5ab1b79cacd68f562467008d176dc23e16e97d4efec9e21741d92ba5087a8433526a45a7e6a9d5ef25408696c402ca1cfbc01a90bf0
-  languageName: node
-  linkType: hard
-
-"jsonstream-next@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "jsonstream-next@npm:3.0.0"
-  dependencies:
-    jsonparse: "npm:^1.2.0"
-    through2: "npm:^4.0.2"
-  bin:
-    jsonstream-next: bin.js
-  checksum: 10c0/96c4547f001d60035291182cb4f4d6af505426c34f74835ac7c7c72d68266e0f99f048328e91eac3a2a53cf58b2b4eee655568940fd2eb74545da55a6e7a5b73
   languageName: node
   linkType: hard
 
@@ -7034,13 +6959,6 @@ __metadata:
     promise-retry: "npm:^2.0.1"
     ssri: "npm:^10.0.0"
   checksum: 10c0/df5f4dbb6d98153b751bccf4dc4cc500de85a96a9331db9805596c46aa9f99d9555983954e6c1266d9f981ae37a9e4647f42b9a4bb5466f867f4012e582c9e7e
-  languageName: node
-  linkType: hard
-
-"map-stream@npm:0.0.7":
-  version: 0.0.7
-  resolution: "map-stream@npm:0.0.7"
-  checksum: 10c0/77da244656dad5013bd147b0eef6f0343a212f14761332b97364fe348d4d70f0b8a0903457d6fc88772ec7c3d4d048b24f8db3aa5c0f77a8ce8bf2391473b8ec
   languageName: node
   linkType: hard
 
@@ -7958,33 +7876,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:0.1.10":
-  version: 0.1.10
-  resolution: "path-to-regexp@npm:0.1.10"
-  checksum: 10c0/34196775b9113ca6df88e94c8d83ba82c0e1a2063dd33bfe2803a980da8d49b91db8104f49d5191b44ea780d46b8670ce2b7f4a5e349b0c48c6779b653f1afe4
-  languageName: node
-  linkType: hard
-
-"path-to-regexp@npm:0.1.7":
-  version: 0.1.7
-  resolution: "path-to-regexp@npm:0.1.7"
-  checksum: 10c0/50a1ddb1af41a9e68bd67ca8e331a705899d16fb720a1ea3a41e310480948387daf603abb14d7b0826c58f10146d49050a1291ba6a82b78a382d1c02c0b8f905
-  languageName: node
-  linkType: hard
-
-"path-to-regexp@npm:2.2.1":
-  version: 2.2.1
-  resolution: "path-to-regexp@npm:2.2.1"
-  checksum: 10c0/f4b51090a73dad5ce0720f13ce8528ac77914bc927d72cc4ba05ab32770ad3a8d2e431962734b688b9ed863d4098d858da6ff4746037e4e24259cbd3b2c32b79
-  languageName: node
-  linkType: hard
-
-"path-to-regexp@npm:^1.8.0":
-  version: 1.9.0
-  resolution: "path-to-regexp@npm:1.9.0"
-  dependencies:
-    isarray: "npm:0.0.1"
-  checksum: 10c0/de9ddb01b84d9c2c8e2bed18630d8d039e2d6f60a6538595750fa08c7a6482512257464c8da50616f266ab2cdd2428387e85f3b089e4c3f25d0c537e898a0751
+"path-to-regexp@npm:^0.1.10":
+  version: 0.1.11
+  resolution: "path-to-regexp@npm:0.1.11"
+  checksum: 10c0/8ad06c6ac418cde34db4b0792204a628667a67141dc197cb85b5ad9f35810cbee34bd1aed336f960876dbd47326df30c8c5774fedf501cd67de87fb08384cfdf
   languageName: node
   linkType: hard
 
@@ -7992,15 +7887,6 @@ __metadata:
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
   checksum: 10c0/666f6973f332f27581371efaf303fd6c272cc43c2057b37aa99e3643158c7e4b2626549555d88626e99ea9e046f82f32e41bbde5f1508547e9a11b149b52387c
-  languageName: node
-  linkType: hard
-
-"pause-stream@npm:^0.0.11":
-  version: 0.0.11
-  resolution: "pause-stream@npm:0.0.11"
-  dependencies:
-    through: "npm:~2.3"
-  checksum: 10c0/86f12c64cdaaa8e45ebaca4e39a478e1442db8b4beabc280b545bfaf79c0e2f33c51efb554aace5c069cc441c7b924ba484837b345eaa4ba6fc940d62f826802
   languageName: node
   linkType: hard
 
@@ -8752,17 +8638,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:3, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0":
-  version: 3.6.2
-  resolution: "readable-stream@npm:3.6.2"
-  dependencies:
-    inherits: "npm:^2.0.3"
-    string_decoder: "npm:^1.1.1"
-    util-deprecate: "npm:^1.0.1"
-  checksum: 10c0/e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
-  languageName: node
-  linkType: hard
-
 "readable-stream@npm:^2.0.5, readable-stream@npm:~2.3.6":
   version: 2.3.8
   resolution: "readable-stream@npm:2.3.8"
@@ -8775,6 +8650,17 @@ __metadata:
     string_decoder: "npm:~1.1.1"
     util-deprecate: "npm:~1.0.1"
   checksum: 10c0/7efdb01f3853bc35ac62ea25493567bf588773213f5f4a79f9c365e1ad13bab845ac0dae7bc946270dc40c3929483228415e92a3fc600cc7e4548992f41ee3fa
+  languageName: node
+  linkType: hard
+
+"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0":
+  version: 3.6.2
+  resolution: "readable-stream@npm:3.6.2"
+  dependencies:
+    inherits: "npm:^2.0.3"
+    string_decoder: "npm:^1.1.1"
+    util-deprecate: "npm:^1.0.1"
+  checksum: 10c0/e37be5c79c376fdd088a45fa31ea2e423e5d48854be7a22a58869b4e84d25047b193f6acb54f1012331e1bcd667ffb569c01b99d36b0bd59658fb33f513511b7
   languageName: node
   linkType: hard
 
@@ -8813,13 +8699,6 @@ __metadata:
   dependencies:
     picomatch: "npm:^2.2.1"
   checksum: 10c0/6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
-  languageName: node
-  linkType: hard
-
-"readline-transform@npm:1.0.0":
-  version: 1.0.0
-  resolution: "readline-transform@npm:1.0.0"
-  checksum: 10c0/504f8918453cac366c375aef1181f312bd05df5f8049686d0b4ad5d4214ecbf844c7470af2027f19051141e6a90dac4dfb9f3e2689ba652a3cf059d730517ec5
   languageName: node
   linkType: hard
 
@@ -9542,15 +9421,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"split@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "split@npm:1.0.1"
-  dependencies:
-    through: "npm:2"
-  checksum: 10c0/7f489e7ed5ff8a2e43295f30a5197ffcb2d6202c9cf99357f9690d645b19c812bccf0be3ff336fea5054cda17ac96b91d67147d95dbfc31fbb5804c61962af85
-  languageName: node
-  linkType: hard
-
 "sprintf-js@npm:^1.1.3":
   version: 1.1.3
   resolution: "sprintf-js@npm:1.1.3"
@@ -9614,16 +9484,6 @@ __metadata:
   version: 2.2.5
   resolution: "stream-chain@npm:2.2.5"
   checksum: 10c0/c512f50190d7c92d688fa64e7af540c51b661f9c2b775fc72bca38ea9bca515c64c22c2197b1be463741daacbaaa2dde8a8ea24ebda46f08391224f15249121a
-  languageName: node
-  linkType: hard
-
-"stream-combiner@npm:^0.2.2":
-  version: 0.2.2
-  resolution: "stream-combiner@npm:0.2.2"
-  dependencies:
-    duplexer: "npm:~0.1.1"
-    through: "npm:~2.3.4"
-  checksum: 10c0/b5d2782fbfa9251c88e01af1b1f54bc183673a776989dce2842b345be7fc3ce7eb2eade363b3c198ba0e5153a20a96e0014d0d0e884153f885d7ee919f22b639
   languageName: node
   linkType: hard
 
@@ -10068,16 +9928,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"through2@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "through2@npm:4.0.2"
-  dependencies:
-    readable-stream: "npm:3"
-  checksum: 10c0/3741564ae99990a4a79097fe7a4152c22348adc4faf2df9199a07a66c81ed2011da39f631e479fdc56483996a9d34a037ad64e76d79f18c782ab178ea9b6778c
-  languageName: node
-  linkType: hard
-
-"through@npm:2, through@npm:^2.3.6, through@npm:^2.3.8, through@npm:~2.3, through@npm:~2.3.4":
+"through@npm:^2.3.6":
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
@@ -10950,7 +10801,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.0.0, yargs@npm:^17.7.2":
+"yargs@npm:^17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:


### PR DESCRIPTION
I forked this repo recently, and Dependabot created 3(!) security alerts for vulnerable transitive dependencies. The vulnerability scores range from low to high. Sadly Dependabot seems unable to automatically update these dependencies, so I've overridden the versions in the package.json resolutions so that a version that isn't vulnerable is now used.

I also replaced the audit-ci package with the new native yarn npm audit command in yarn 4. The audit-ci NPM package that was previously used does not support being used in yarn v4 (see https://www.npmjs.com/package/audit-ci)

Finally I added the --refresh-lockfile argument to the CI pipelines to ensure lockfile data is consistent as is stated on the yarn wiki:
If used together with --immutable, it can validate that the lockfile information are consistent

No breaking changes.